### PR TITLE
Add pillow to pip.toml

### DIFF
--- a/deps/pip.toml
+++ b/deps/pip.toml
@@ -72,6 +72,7 @@ packages = [
     "pyperclip==1.8.0",                     # SWIPAT filed under: https://nvbugs/5326856
     "python-dateutil==2.9.0.post0",         # SWIPAT filed under: https://nvbugs/5303032
     "six==1.17.0",                          # SWIPAT filed under: https://nvbugs/5303087
+    "pillow",
 ]
 
 target = "../_build/target-deps/isaac_core_prebundle"


### PR DESCRIPTION
## Description

Add `pillow` to `pip.toml`, I don't know what to add to the comments section.

Reduced the number of errors from 92 to 27

## Bug snippet

```
2025-06-18T15:47:21Z [3,184ms] [Info] [carb] `add_item` is deprecated. use omni.kit.menu.utils instead. Callstack:   File "/home/ubuntu/.cache/packman/chk/kit-kernel/107.3.0+feature.199947.b0a86421.gl.manylinux_2_35_x86_64.release/kernel/py/carb/profiler/__init__.py", line 99, in wrapper
    r = f(*args, **kwds)
  File "/home/ubuntu/.cache/packman/chk/kit-kernel/107.3.0+feature.199947.b0a86421.gl.manylinux_2_35_x86_64.release/kernel/py/omni/ext/_impl/_internal.py", line 173, in _startup_ext
    instance.on_startup(self._ext_id)
  File "/home/ubuntu/workspaces/IsaacSim/_build/linux-x86_64/release/extscache/omni.kit.window.material_graph-1.8.23/omni/kit/window/material_graph/graph_extension.py", line 68, in on_startup
    self._menu = editor_menu.add_item(
  File "/home/ubuntu/.cache/packman/chk/kit-kernel/107.3.0+feature.199947.b0a86421.gl.manylinux_2_35_x86_64.release/kernel/py/carb/__init__.py", line 107, in wrapped
    obj.__name__, message, "".join(traceback.format_stack(limit=4))[:-1]
2025-06-18T15:47:21Z [3,193ms] [Error] [omni.ext._impl.custom_importer] Failed to import python module omni.kit.window.material_graph.tests. Error: No module named 'PIL'. Traceback:
Traceback (most recent call last):
  File "/home/ubuntu/.cache/packman/chk/kit-kernel/107.3.0+feature.199947.b0a86421.gl.manylinux_2_35_x86_64.release/kernel/py/omni/ext/_impl/custom_importer.py", line 85, in import_module
    return importlib.import_module(name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.cache/packman/chk/kit-kernel/107.3.0+feature.199947.b0a86421.gl.manylinux_2_35_x86_64.release/python/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/ubuntu/workspaces/IsaacSim/_build/linux-x86_64/release/extscache/omni.kit.window.material_graph-1.8.23/omni/kit/window/material_graph/tests/__init__.py", line 9, in <module>
    from .material_graph_test import TestMaterialGraph
  File "/home/ubuntu/workspaces/IsaacSim/_build/linux-x86_64/release/extscache/omni.kit.window.material_graph-1.8.23/omni/kit/window/material_graph/tests/material_graph_test.py", line 17, in <module>
    from omni.ui.tests.test_base import OmniUiTest
  File "/home/ubuntu/workspaces/IsaacSim/_build/linux-x86_64/release/extscache/omni.ui-2.26.17+b0a86421.lx64.r.cp311/omni/ui/tests/__init__.py", line 18, in <module>
    from .test_image import TestImage
  File "/home/ubuntu/workspaces/IsaacSim/_build/linux-x86_64/release/extscache/omni.ui-2.26.17+b0a86421.lx64.r.cp311/omni/ui/tests/test_image.py", line 11, in <module>
    from PIL import Image
ModuleNotFoundError: No module named 'PIL'

2025-06-18T15:47:21Z [3,193ms] [Error] [carb.scripting-python.plugin] Exception: Extension python module: 'omni.kit.window.material_graph.tests' in '/home/ubuntu/workspaces/IsaacSim/_build/linux-x86_64/release/extscache/omni.kit.window.material_graph-1.8.23' failed to load.

At:
  /home/ubuntu/.cache/packman/chk/kit-kernel/107.3.0+feature.199947.b0a86421.gl.manylinux_2_35_x86_64.release/kernel/py/omni/ext/_impl/_internal.py(222): startup
  /home/ubuntu/.cache/packman/chk/kit-kernel/107.3.0+feature.199947.b0a86421.gl.manylinux_2_35_x86_64.release/kernel/py/omni/ext/_impl/_internal.py(337): startup_extension
  PythonExtension.cpp::startup()(2): <module>

2025-06-18T15:47:21Z [3,193ms] [Error] [omni.ext.plugin] [ext: omni.kit.window.material_graph-1.8.23] Failed to startup python extension.
```

## Full log

before: [kit_20250618_234718.log](https://github.com/user-attachments/files/20800394/kit_20250618_234718.log)

after: [kit_20250619_000008.log](https://github.com/user-attachments/files/20800400/kit_20250619_000008.log)

