### PR TITLE
Fix to use to_numpy utils for joint velocity and effort in ArticulationController

### DIFF
--- a/source/extensions/isaacsim.core.api/python/impl/controllers/articulation_controller.py
+++ b/source/extensions/isaacsim.core.api/python/impl/controllers/articulation_controller.py
@@ -78,7 +78,9 @@ class ArticulationController(object):
             )
             joint_velocities = self._articulation_view._backend_utils.expand_dims(joint_velocities, 0)
             for i in range(control_actions.get_length()):
-                if joint_velocities[0][i] is None or np.isnan(joint_velocities[0][i]):
+                if joint_velocities[0][i] is None or np.isnan(
+                    self._articulation_view._backend_utils.to_numpy(joint_velocities[0][i])
+                ):
                     joint_velocities[0][i] = applied_actions.joint_velocities[joint_indices[i]]
         joint_efforts = control_actions.joint_efforts
         if control_actions.joint_efforts is not None:
@@ -87,7 +89,9 @@ class ArticulationController(object):
             )
             joint_efforts = self._articulation_view._backend_utils.expand_dims(joint_efforts, 0)
             for i in range(control_actions.get_length()):
-                if joint_efforts[0][i] is None or np.isnan(joint_efforts[0][i]):
+                if joint_efforts[0][i] is None or np.isnan(
+                    self._articulation_view._backend_utils.to_numpy(joint_efforts[0][i])
+                ):
                     joint_efforts[0][i] = 0
         self._articulation_view.apply_action(
             ArticulationActions(


### PR DESCRIPTION
Currently, `ArticulationController` only converts joint position tensors to NumPy arrays when checking them. As a result, joint velocity and effort remain in their original (e.g. GPU) tensor format, which can lead to unexpected downstream errors when consuming those values in NumPy‐based workflows.

This PR simply extends the existing to_numpy utility calls to also cover: `Joint velocity` & `Joint effort`

Although this repo typically does not accept external PRs per its contribution guidelines, I encountered this minor issue during simulation development and thought the fix would benefit other users. I appreciate your consideration!