### PR TITLE
Fix path formatting in generating VSCode settings for Windows compatibility

### DIFF
--- a/source/python_packages/isaacsim/__main__.py
+++ b/source/python_packages/isaacsim/__main__.py
@@ -120,10 +120,10 @@ def generate_vscode_settings():
 
     # update 'python.defaultInterpreterPath'
     template = VSCODE_SETTINGS_TEMPLATE[:]
-    template = template.replace("PYTHON.DEFAULTINTERPRETERPATH", sys.executable)
+    template = template.replace("PYTHON.DEFAULTINTERPRETERPATH", sys.executable.replace("\\", "/"))
 
     # update 'python.analysis.extraPaths'
-    content = "\n".join([f'"{path}",' for path in extensions_paths])
+    content = "\n".join([f'"{path.replace(chr(92), "/")}",' for path in extensions_paths])
     content = textwrap.indent(content, prefix=" " * 8)[8:]
     template = template.replace("PYTHON.ANALYSIS.EXTRAPATHS", content)
 


### PR DESCRIPTION
### Description

Hi @sheikh-nv , @vick-yu , I'm reporting an issue I encountered when using `python -m isaacsim --generate-vscode-settings` to create the VS Code configuration, particularly on Windows. Following the [Visual Studio Code Support](https://docs.isaacsim.omniverse.nvidia.com/latest/installation/install_python.html#visual-studio-code-support), the generated `.vscode/settings.json` contains unescaped backslashes in the `python.defaultInterpreterPath` and `python.analysis.extraPaths` entries.


<img width="1274" height="473" alt="image" src="https://github.com/user-attachments/assets/6573b1e7-1fcc-4764-bd84-b40cf6bb5636" />

The root cause is 

https://github.com/isaac-sim/IsaacSim/blob/07d8dd47ea6b3c48b6b9d57fb6d8f7413914b40f/source/python_packages/isaacsim/__main__.py#L123

and

https://github.com/isaac-sim/IsaacSim/blob/07d8dd47ea6b3c48b6b9d57fb6d8f7413914b40f/source/python_packages/isaacsim/__main__.py#L128

I understand that Isaac Sim typically does not accept direct contributions via pull requests. Therefore, please feel free to close this PR without merging. This is simply to highlight the issue and provide a ready-to-use solution for your team to consider at your convenience.

Thank you for developing Isaac Sim!

### Isaac Sim version

5.0.0

### Operating System (OS)

Windows 11

### GPU Name

RTX 4080

### GPU Driver and CUDA versions

Driver Version: 566.24, CUDA Version: 12.7

### Logs


### Additional information







