### PR TITLE
fix: change calculation from fy to match square pixel assumption

### DIFF
--- a/source/extensions/isaacsim.ros2.bridge/python/impl/camera_info_utils.py
+++ b/source/extensions/isaacsim.ros2.bridge/python/impl/camera_info_utils.py
@@ -81,10 +81,10 @@ def read_camera_info(render_product_path: str) -> Tuple:
         width, height = get_resolution(render_product_path=render_product_path)
         focalLength = camera_prim.GetAttribute("focalLength").Get()
         horizontalAperture = camera_prim.GetAttribute("horizontalAperture").Get()
-        verticalAperture = camera_prim.GetAttribute("verticalAperture").Get()
 
+        # We assume that we have square pixels so fy = height * focalLength / (horizontalAperture * (height / width))
         fx = width * focalLength / horizontalAperture
-        fy = height * focalLength / verticalAperture
+        fy = height * focalLength / (horizontalAperture * (height / width))
         cx = width * 0.5
         cy = height * 0.5
 


### PR DESCRIPTION
# Align camera_info intrinsics with depth → point cloud (square pixels assumption)

## Summary
This PR updates the fy calculation in `camera_info_utils.py` so that it matches the depth → point cloud implementation (`OgnIsaacConvertDepthToPointCloud.cpp`).  

Previously, `camera_info_utils.py` calculated fy using the **vertical aperture**:  
```
fy = height * focalLength / verticalAperture
```

But in depth → point cloud, fy was already implemented as:  
```cpp
// We assume that we have square pixels so fy = height * focalLength / (horizontalAperture * (height / width))
fx = width * focalLength / horizontalAperture;
fy = height * focalLength / (horizontalAperture * (height / width));
cx = width * 0.5f;
cy = height * 0.5f;
```

This simplifies to:  
```
fy = width * focalLength / horizontalAperture
```
which makes fy the same as fx.  

With this PR, `camera_info_utils.py` now uses the same formula as the depth → point cloud path, enforcing the **square pixel assumption** consistently.  

## Why
- Avoids mismatched intrinsics between camera_info and depth_pcl.  
- Makes the assumption of **square pixels** explicit (sensor aspect ratio must match resolution).  
- Keeps behavior consistent across both camera_info and point cloud generation.  

## Recommendation
- Update the documentation to clearly state that square pixels **must** be used.  
- Clarify that both fx and fy are derived from the horizontal aperture under this assumption.  

## References
- Related issue: [#199](https://github.com/isaac-sim/IsaacSim/issues/199)  
- Forum discussion: https://forums.developer.nvidia.com/t/bug-ros2-omnigraph-camera-info-camera-intrisics/344939/3  
- Depth → point cloud code: [OgnIsaacConvertDepthToPointCloud.cpp#L60](https://github.com/isaac-sim/IsaacSim/blob/07d8dd47ea6b3c48b6b9d57fb6d8f7413914b40f/source/extensions/isaacsim.core.nodes/nodes/OgnIsaacConvertDepthToPointCloud.cpp#L60)  
- Camera info utils: [camera_info_utils.py#L87](https://github.com/isaac-sim/IsaacSim/blob/07d8dd47ea6b3c48b6b9d57fb6d8f7413914b40f/source/extensions/isaacsim.ros2.bridge/python/impl/camera_info_utils.py#L87)  