### PR TITLE
Fixed notebook_dir to always be defined

### DIFF
--- a/source/extensions/isaacsim.code_editor.jupyter/data/launchers/jupyter_launcher.py
+++ b/source/extensions/isaacsim.code_editor.jupyter/data/launchers/jupyter_launcher.py
@@ -110,6 +110,8 @@ if __name__ == "__main__":
     if not argv[3]:
         notebook_dir = os.path.abspath(os.path.join(SCRIPT_DIR, "..", "notebooks"))
         notebook_dir = "--notebook-dir={}".format(notebook_dir)
+    else:
+        notebook_dir = argv[3]
 
     # get token
     token = "--ServerApp.token={}".format(token)


### PR DESCRIPTION
## Description

I installed the Jupyter Code Editor extension via the Isaac Sim CLI, which worked as expected. However when I try to change the notebook directory via `--/exts/isaacsim.code_editor.jupyter/notebook_dir` or the 'extension.toml' file, I get the below log statements:

```
File ".../.venv/lib/python3.11/site-packages/isaacsim/exts/isaacsim.code_editor.jupyter/data/launchers/jupyter_launcher.py", line 130, in <module>
    argv = app_dir + [token] + [notebook_dir] + argv[4].split(" ")
                                ^^^^^^^^^^^^
NameError: name 'notebook_dir' is not defined
```

This error prevents the Jupyter Code Editor extension from starting

## Solution
Add the bottom 2 lines to `IsaacSim/source/extensions/isaacsim.code_editor.jupyter/data/launchers/jupyter_launcher.py`, line 109:

```python
    # get notebook_dir
    if not argv[3]:
        notebook_dir = os.path.abspath(os.path.join(SCRIPT_DIR, "..", "notebooks"))
        notebook_dir = "--notebook-dir={}".format(notebook_dir)
    else:
        notebook_dir = argv[3]
```

Without the else statement, the notebook_dir variable is undefined when defining a notebook_dir via the CLI or extension.toml file, as argv[3] exists. This change was tested locally and allows for changing the Jupyter Notebook directory.

## Isaac Sim version

5.0.0

## Operating System (OS)

Ubuntu 24.04.3 

## GPU Name

RTX 3090 Ti

## GPU Driver and CUDA versions

Driver Version: 570.172 Cuda: 12.8

## Logs

```
File ".../.venv/lib/python3.11/site-packages/isaacsim/exts/isaacsim.code_editor.jupyter/data/launchers/jupyter_launcher.py", line 130, in <module>
    argv = app_dir + [token] + [notebook_dir] + argv[4].split(" ")
                                ^^^^^^^^^^^^
NameError: name 'notebook_dir' is not defined
```

## Additional information