### PR TITLE
[RootlessDocker] Set correct group permissions in Dockerfile to allow users to be added to group

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -45,6 +45,9 @@ USER isaac-sim
 RUN mkdir -p /isaac-sim
 WORKDIR /isaac-sim
 COPY --chown=isaac-sim:isaac-sim . /isaac-sim/
+# Set group write and execute permissions so any user in isaac-sim group can
+# create, modify or execute files
+RUN chmod -R g+wsx /isaac-sim /tmp
 RUN mkdir -p /isaac-sim/.nvidia-omniverse/config
 
 # Open ports for live streaming


### PR DESCRIPTION
This pull request introduces a permissions update in the Docker build process to improve collaboration for users in the `isaac-sim` group. The main change ensures that all users in the group can create, modify, or execute files within the `/isaac-sim` and `/tmp` directories.

Permissions and collaboration:

* Added a `chmod -R g+wsx /isaac-sim /tmp` command to grant group write and execute permissions, facilitating shared access for all users in the `isaac-sim` group.

@sheikh-nv It would be nice if this change could be incoorporated into the Dockerfile such that downstream rootless docker images can create users that mirror local user permissions and work seamlessly.

Currently, adding a new user to the `isaac-sim` group does not provide necessary privileges, which is limiting. 