### PR TITLE
feat: add support to build with docker and natively

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,4 +7,4 @@
 
 #### Contribution
 
-- We currently do not acccept any contributions to this repository.
+- We currently do not accept any contributions to this repository.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Ensure your system is set up with the following before building Isaac Sim:
 
   > **(Linux) Ubuntu 24.04**
   > Ubuntu 24.04 is not fully supported at this time. Building with Ubuntu 24.04 requires GCC/G++ 11 to be installed, GCC/G++ 12+ is not supported.
+  > Alternatively, use the containerized build which includes GCC 11:
+  > ```bash
+  > ./tools/docker/prep_docker_build.sh --docker-build
+  > ```
 
 - **GPU**: For additional information on GPU features and requirements, see [NVIDIA GPU Requirements](https://docs.omniverse.nvidia.com/dev-guide/latest/common/technical-requirements.html)
 
@@ -166,6 +170,21 @@ isaac-sim.bat
 ```
 
 > NOTE: If this is your first time building Isaac Sim, you will be prompted to accept the Omniverse Licensing Terms.
+
+### Docker Deployment (Linux)
+
+Build and run Isaac Sim in a Docker container:
+
+```bash
+# Build (one-time)
+./tools/docker/prep_docker_build.sh --docker-build
+./tools/docker/build_docker.sh
+
+# Run
+./tools/docker/run_docker.sh -c "./isaac-sim.sh"
+```
+
+See [tools/docker/README.md](tools/docker/README.md) for details.
 
 
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -6,6 +6,9 @@ ENV NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=all
 RUN touch /etc/ld.so.nohwcap
 
 # Install dependencies
+# Note: GCC 11 is included to support containerized builds on hosts with incompatible
+# compilers (e.g., Ubuntu 24.04 with GCC 13). Isaac Sim requires GCC 11 for compilation.
+# This enables: ./tools/docker/prep_docker_build.sh --docker-build
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         curl \
@@ -23,6 +26,14 @@ RUN apt-get update \
         ca-certificates \
         libglib2.0-0 \
         libnghttp2-14 \
+        # Build and prep tools
+        build-essential \
+        gcc-11 \
+        g++-11 \
+        python3-pip \
+        rsync \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100 \
     && apt-get -y autoremove \
     && apt-get clean autoclean \
     && rm -rf /var/lib/apt/lists/*

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -109,6 +109,11 @@ Use `run_docker.sh` to run the built image. Reference: [NVIDIA Container Docs](h
 
 **Persistent cache**: Extensions and shaders are cached in `_isaac_cache/`. First run downloads ~150 extensions (~3-5 min); subsequent runs are fast.
 
+**Cleaning**: Remove all Docker artifacts (build context and runtime cache):
+```bash
+./tools/docker/clean_docker.sh
+```
+
 ## Important Notes
 
 - **Build Requirements**: The `_build/$CONTAINER_PLATFORM/release` directory must exist before running the Docker preparation. Use `--build` or `--docker-build` option if you haven't built Isaac Sim yet.
@@ -126,4 +131,3 @@ Use `run_docker.sh` to run the built image. Reference: [NVIDIA Container Docs](h
 - **Docker build fails**: Check that Docker daemon is running and you have sufficient disk space.
 - **GCC version not supported (Ubuntu 24.04+)**: Use `--docker-build` which includes GCC 11.
 - **No GUI window**: Check `xhost +local:docker` ran successfully and `$DISPLAY` is set.
-- **Permission denied on cache**: `run_docker.sh` auto-fixes with `sudo chown`.

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -9,6 +9,7 @@ Before running these scripts, ensure you have the following installed on your ho
 - **rsync** - Required for file synchronization during the preparation phase
 - **python3** - Required for running the preparation scripts and installing dependencies
 - **Docker** - Required for building the final image
+- **NVIDIA Container Toolkit** - Required for GPU access in containers
 
 ### Installing Prerequisites
 
@@ -31,8 +32,8 @@ Use `prep_docker_build.sh` to prepare the Docker build context:
 ```
 
 #### Options:
-- `--build` - Run the full Isaac Sim build sequence before preparing Docker files:
-  - Executes `build.sh -r`
+- `--build` - Run the full Isaac Sim build sequence before preparing Docker files (requires GCC 11)
+- `--docker-build` - Build Isaac Sim inside a container (no host dependencies except Docker). **Recommended for Ubuntu 24.04+** which ships with GCC 13.
 - `--x86_64` - Build x86_64 container (default)
 - `--aarch64` - Build aarch64 container
 - `--skip-dedupe` - Skip the file deduplication process (faster but larger image)
@@ -63,7 +64,13 @@ Use `build_docker.sh` to build the actual Docker image:
 
 ## Example Usage
 
-### Basic build:
+### Containerized build (Ubuntu 24.04+ or no native dependencies):
+```bash
+./tools/docker/prep_docker_build.sh --docker-build
+./tools/docker/build_docker.sh
+```
+
+### Native build (requires GCC 11):
 ```bash
 # Prepare build environment (includes full build)
 ./tools/docker/prep_docker_build.sh --build
@@ -90,9 +97,22 @@ Use `build_docker.sh` to build the actual Docker image:
 ./tools/docker/build_docker.sh
 ```
 
+## Running Isaac Sim
+
+Use `run_docker.sh` to run the built image. Reference: [NVIDIA Container Docs](https://docs.isaacsim.omniverse.nvidia.com/latest/installation/install_container.html)
+
+```bash
+./tools/docker/run_docker.sh -c "./isaac-sim.sh"           # GUI
+./tools/docker/run_docker.sh -c "./runheadless.sh -v"      # Headless + livestream
+./tools/docker/run_docker.sh -c "./isaac-sim.sh --help"    # Help
+```
+
+**Persistent cache**: Extensions and shaders are cached in `_isaac_cache/`. First run downloads ~150 extensions (~3-5 min); subsequent runs are fast.
+
 ## Important Notes
 
-- **Build Requirements**: The `_build/$CONTAINER_PLATFORM/release` directory must exist before running the Docker preparation. Use `--build` option if you haven't built Isaac Sim yet.
+- **Build Requirements**: The `_build/$CONTAINER_PLATFORM/release` directory must exist before running the Docker preparation. Use `--build` or `--docker-build` option if you haven't built Isaac Sim yet.
+- **Ubuntu 24.04+**: Use `--docker-build` which includes GCC 11. Native build requires manually installing GCC 11.
 - **Deduplication**: The deduplication process can significantly reduce Docker image size by replacing duplicate files with symlinks, but it takes time. Use `--skip-dedupe` for faster rebuilds during development.
 - **File Paths**: The deduplication process skips files with spaces in their paths for reliability.
 - **Build Context**: The final Docker build uses `_container_temp` as the build context and `tools/docker/Dockerfile` as the Dockerfile.
@@ -100,7 +120,10 @@ Use `build_docker.sh` to build the actual Docker image:
 
 ## Troubleshooting
 
-- **Error: "_build/$CONTAINER_PLATFORM/release does not exist"**: Run the script with `--build` option to build Isaac Sim first.
+- **Error: "_build/$CONTAINER_PLATFORM/release does not exist"**: Run the script with `--build` or `--docker-build` option to build Isaac Sim first.
 - **rsync not found**: Install rsync using your system's package manager.
 - **Python requirements installation fails**: Ensure python3 and pip are properly installed.
 - **Docker build fails**: Check that Docker daemon is running and you have sufficient disk space.
+- **GCC version not supported (Ubuntu 24.04+)**: Use `--docker-build` which includes GCC 11.
+- **No GUI window**: Check `xhost +local:docker` ran successfully and `$DISPLAY` is set.
+- **Permission denied on cache**: `run_docker.sh` auto-fixes with `sudo chown`.

--- a/tools/docker/clean_docker.sh
+++ b/tools/docker/clean_docker.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Clean Docker build artifacts and runtime cache
+
+IMAGE_TAG="isaac-sim-docker:latest"
+SCRIPT_DIR=$(dirname ${BASH_SOURCE})
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+echo "Cleaning Docker artifacts..."
+
+# _container_temp: build context (host ownership)
+rm -rf "${REPO_ROOT}/_container_temp"
+
+# _isaac_cache: runtime cache (uid 1234 ownership, use Docker to clean)
+if [[ -d "${REPO_ROOT}/_isaac_cache" ]]; then
+    docker run --rm --entrypoint rm -v "${REPO_ROOT}/_isaac_cache":/cache "${IMAGE_TAG}" -rf /cache
+    rmdir "${REPO_ROOT}/_isaac_cache" 2>/dev/null || rm -rf "${REPO_ROOT}/_isaac_cache"
+fi
+
+echo "Done."

--- a/tools/docker/prep_docker_build.sh
+++ b/tools/docker/prep_docker_build.sh
@@ -123,10 +123,6 @@ if [[ "$DOCKER_BUILD" == "true" ]]; then
         echo "Containerized build failed, exiting with error code 1" >&2
         exit 1
     fi
-    
-    # Prepare runtime cache directory for run_docker.sh (container runs as uid 1234)
-    mkdir -p _isaac_cache
-    sudo chown -R 1234:1234 _isaac_cache 2>/dev/null || true
 fi
 
 # Check that _build/linux-x86_64 or _build/linux-aarch64 exists

--- a/tools/docker/prep_docker_build.sh
+++ b/tools/docker/prep_docker_build.sh
@@ -4,7 +4,10 @@
 # Parse command line arguments
 SKIP_DEDUPE=false
 RUN_BUILD=false
+DOCKER_BUILD=false
 CONTAINER_PLATFORM=linux-x86_64
+BUILDER_IMAGE="isaac-sim-builder:latest"
+PACKMAN_CACHE_DIR="$(pwd)/_packman_cache"
 
 show_help() {
     cat << EOF
@@ -13,7 +16,8 @@ Usage: $0 [OPTIONS]
 Prepares Docker build by generating rsync script and copying necessary files.
 
 OPTIONS:
-    --build          Build Isaac Sim
+    --build          Build Isaac Sim natively (requires GCC 11)
+    --docker-build   Build Isaac Sim inside a container (recommended for Ubuntu 24.04+)
     --x86_64         Build x86_64 container (default)
     --aarch64        Build aarch64 container
     --skip-dedupe    Skip the deduplication process
@@ -31,8 +35,38 @@ build_function() {
         return 1
     fi
 
-
     echo "Build sequence completed successfully!"
+}
+
+docker_build_function() {
+    echo "Building Isaac Sim inside container..."
+
+    # Build the builder image from the Dockerfile (has GCC 11)
+    if ! docker build -t "$BUILDER_IMAGE" -f tools/docker/Dockerfile tools/docker/; then
+        echo "Error: Failed to build builder image" >&2
+        return 1
+    fi
+
+    # Create the packman cache directory
+    # This is mounted inside the container so symlinks created during build
+    # point to paths that exist on both host and container
+    mkdir -p "$PACKMAN_CACHE_DIR"
+
+    # Run build inside container with source mounted
+    # Mount packman cache to the SAME path used inside container so symlinks work on host
+    # Run with host user's UID/GID to ensure build artifacts have correct ownership
+    if ! docker run --rm --user "$(id -u):$(id -g)" --entrypoint bash \
+        -e TERM=xterm-256color \
+        -v "$(pwd):/workspace" \
+        -v "$PACKMAN_CACHE_DIR:$PACKMAN_CACHE_DIR" \
+        -e PM_PACKAGES_ROOT="$PACKMAN_CACHE_DIR" \
+        -w /workspace "$BUILDER_IMAGE" \
+        -c "touch .eula_accepted && ./build.sh -r"; then
+        echo "Error: Containerized build failed" >&2
+        return 1
+    fi
+
+    echo "Containerized build completed successfully!"
 }
 
 # Parse command line options
@@ -44,6 +78,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --build)
             RUN_BUILD=true
+            shift
+            ;;
+        --docker-build)
+            DOCKER_BUILD=true
             shift
             ;;
         --x86_64)
@@ -77,39 +115,76 @@ if [[ "$RUN_BUILD" == "true" ]]; then
     fi
 fi
 
+# Run containerized build if --docker-build was specified
+if [[ "$DOCKER_BUILD" == "true" ]]; then
+    echo ""
+    docker_build_function
+    if [[ $? -ne 0 ]]; then
+        echo "Containerized build failed, exiting with error code 1" >&2
+        exit 1
+    fi
+    
+    # Prepare runtime cache directory for run_docker.sh (container runs as uid 1234)
+    mkdir -p _isaac_cache
+    sudo chown -R 1234:1234 _isaac_cache 2>/dev/null || true
+fi
+
 # Check that _build/linux-x86_64 or _build/linux-aarch64 exists
 if [[ ! -d "_build/${CONTAINER_PLATFORM}/release" ]]; then
     echo "Error: _build/${CONTAINER_PLATFORM}/release does not exist" >&2
-    echo "Please rerun the script with --build" >&2
+    echo "Please rerun the script with --build or --docker-build" >&2
     exit 1
 fi
 
 
-# Goes a bit faster if you have used PM_PATH_TO_SANDBOX="_"
-if ! python3 -m pip install -r tools/docker/requirements.txt; then
-    echo "Failed to install Python requirements" >&2
-    exit 1
+# Prep steps: generate rsync, copy files
+# Use container if --docker-build was specified (no host dependencies)
+# Otherwise use native Python (original behavior)
+if [[ "$DOCKER_BUILD" == "true" ]]; then
+    PACKMAN_CACHE_DIR="$(pwd)/_packman_cache"
+    
+    if ! docker build -q -t "$BUILDER_IMAGE" -f tools/docker/Dockerfile tools/docker/ >/dev/null; then
+        echo "Error: Failed to build prep image" >&2
+        exit 1
+    fi
+
+    if ! docker run --rm --user "$(id -u):$(id -g)" --entrypoint bash \
+        -v "$(pwd):/workspace" \
+        -v "$PACKMAN_CACHE_DIR:$PACKMAN_CACHE_DIR" \
+        -e PM_PACKAGES_ROOT="$PACKMAN_CACHE_DIR" \
+        -w /workspace \
+        "$BUILDER_IMAGE" \
+        -c "
+            pip install -q --break-system-packages -r tools/docker/requirements.txt && \
+            python3 tools/docker/generate_rsync_script.py --platform ${CONTAINER_PLATFORM} --target isaac-sim-docker --output-folder _container_temp && \
+            ./generated_rsync_package.sh && \
+            find _container_temp -type d -empty -delete && \
+            cp -r tools/docker/data/* _container_temp
+        "; then
+        echo "Error: Prep failed" >&2
+        exit 1
+    fi
+else
+    echo "Preparing Docker build context..."
+    
+    if ! python3 -m pip install -r tools/docker/requirements.txt; then
+        echo "Failed to install Python requirements" >&2
+        exit 1
+    fi
+
+    if ! python3 tools/docker/generate_rsync_script.py --platform ${CONTAINER_PLATFORM} --target isaac-sim-docker --output-folder _container_temp; then
+        echo "Failed to generate rsync script" >&2
+        exit 1
+    fi
+
+    ./generated_rsync_package.sh
+
+    echo "Removing empty folders"
+    find _container_temp -type d -empty -delete
+
+    echo "Copying data from tools/docker/data"
+    cp -r tools/docker/data/* _container_temp
 fi
-
-
-if ! python3 tools/docker/generate_rsync_script.py --platform ${CONTAINER_PLATFORM} --target isaac-sim-docker --output-folder _container_temp; then
-    echo "Failed to generate rsync script" >&2
-    exit 1
-fi
-
-
-./generated_rsync_package.sh
-
-
-
-echo "Removing empty folders"
-# Remove empty folders from container temp
-find _container_temp -type d -empty -delete
-
-
-echo "Copying data from tools/docker/data"
-
-cp -r tools/docker/data/* _container_temp
 
 
 find_chained_symlinks(){

--- a/tools/docker/run_docker.sh
+++ b/tools/docker/run_docker.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
-PRIVACY_EMAIL="${PRIVACY_EMAIL:-user@example.com}"  # Allow override via environment
+
+IMAGE_TAG="isaac-sim-docker:latest"
+PRIVACY_EMAIL="user@example.com"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CACHE_DIR="${SCRIPT_DIR}/../../_isaac_cache"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CACHE_DIR="${REPO_ROOT}/_isaac_cache"
 
 xhost +local:docker &>/dev/null || true
+
+# Create cache directory with container user ownership (uid 1234)
+mkdir -p "${CACHE_DIR}"
+docker run --rm --entrypoint chown -v "${CACHE_DIR}":/cache "${IMAGE_TAG}" -R 1234:1234 /cache
 
 docker run --name isaac-sim --entrypoint bash -it --gpus all -e "ACCEPT_EULA=Y" --rm \
  --network=host -e "PRIVACY_CONSENT=Y" -e "PRIVACY_USERID=${PRIVACY_EMAIL}" \
  -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix \
- -v "${CACHE_DIR}:/isaac-sim/.local/share/ov/data" \
- isaac-sim-docker:latest "$@"
+ -v "${CACHE_DIR}":/isaac-sim/.local/share/ov \
+ "${IMAGE_TAG}" "$@"

--- a/tools/docker/run_docker.sh
+++ b/tools/docker/run_docker.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 PRIVACY_EMAIL="${PRIVACY_EMAIL:-user@example.com}"  # Allow override via environment
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CACHE_DIR="${SCRIPT_DIR}/../../_isaac_cache"
+
+xhost +local:docker &>/dev/null || true
 
 docker run --name isaac-sim --entrypoint bash -it --gpus all -e "ACCEPT_EULA=Y" --rm \
- --network=host -e "PRIVACY_CONSENT=Y" -e "PRIVACY_USERID=${PRIVACY_EMAIL}" isaac-sim-docker:latest \
- "$@"
+ --network=host -e "PRIVACY_CONSENT=Y" -e "PRIVACY_USERID=${PRIVACY_EMAIL}" \
+ -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix \
+ -v "${CACHE_DIR}:/isaac-sim/.local/share/ov/data" \
+ isaac-sim-docker:latest "$@"


### PR DESCRIPTION
This pull request introduces robust support for building and running Isaac Sim in Docker containers, with a focus on simplifying the setup process for Ubuntu 24.04+ (which ships with an incompatible GCC version). The changes add a containerized build workflow, update documentation to guide users through both native and containerized builds, and provide scripts for building, running, and cleaning Docker artifacts. These updates make it much easier to build and deploy Isaac Sim on systems with newer compilers or minimal host dependencies.

Key changes include:

**Containerized Build and Deployment Support**
- Added a `--docker-build` option to `prep_docker_build.sh` to build Isaac Sim inside a Docker container, ensuring compatibility with Ubuntu 24.04+ and hosts lacking GCC 11. The script now builds a builder image with GCC 11 and runs the build inside the container, mounting necessary volumes for correct artifact ownership and caching. [[1]](diffhunk://#diff-9b0f147710f7d04a0cfd959466f7675ccdda8651de7f0ec31cfa9d1832f62a35R7-R10) [[2]](diffhunk://#diff-9b0f147710f7d04a0cfd959466f7675ccdda8651de7f0ec31cfa9d1832f62a35L16-R20) [[3]](diffhunk://#diff-9b0f147710f7d04a0cfd959466f7675ccdda8651de7f0ec31cfa9d1832f62a35L34-R71) [[4]](diffhunk://#diff-9b0f147710f7d04a0cfd959466f7675ccdda8651de7f0ec31cfa9d1832f62a35R83-R86) [[5]](diffhunk://#diff-9b0f147710f7d04a0cfd959466f7675ccdda8651de7f0ec31cfa9d1832f62a35R118-R183)
- Updated `tools/docker/Dockerfile` to install GCC 11 and set it as the default compiler, enabling containerized builds regardless of the host's GCC version. [[1]](diffhunk://#diff-08a8087328a91b9feba4aef61ff3ffceb1f543e0b599c4b5123174aec94b59a3R9-R11) [[2]](diffhunk://#diff-08a8087328a91b9feba4aef61ff3ffceb1f543e0b599c4b5123174aec94b59a3R29-R36)
- Added `tools/docker/clean_docker.sh` to clean up Docker build artifacts and runtime cache, ensuring a clean environment for repeated builds.
- Enhanced `tools/docker/run_docker.sh` to properly handle cache directory ownership and X11 display forwarding, improving GUI support and cache persistence in containers.

**Documentation Updates**
- Expanded `README.md` and `tools/docker/README.md` with detailed instructions for both native and containerized builds, including example commands, prerequisites (like NVIDIA Container Toolkit), troubleshooting tips, and guidance for Ubuntu 24.04+ users. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R43-R46) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R174-R188) [[3]](diffhunk://#diff-5701757eb2f837a5f4ae8d1e1989a60593fa5d6b2b15580b704a641c5ad6a0c2R12) [[4]](diffhunk://#diff-5701757eb2f837a5f4ae8d1e1989a60593fa5d6b2b15580b704a641c5ad6a0c2L34-R36) [[5]](diffhunk://#diff-5701757eb2f837a5f4ae8d1e1989a60593fa5d6b2b15580b704a641c5ad6a0c2L66-R73) [[6]](diffhunk://#diff-5701757eb2f837a5f4ae8d1e1989a60593fa5d6b2b15580b704a641c5ad6a0c2R100-R133)
- Clarified the difference between native (`--build`) and containerized (`--docker-build`) build options and updated troubleshooting and important notes sections to reflect the new workflow.

**Minor Corrections**
- Fixed a typo in `CONTRIBUTING.md` ("acccept" → "accept").