### PR TITLE
Fix floating-base gravity compensation DOF indexing

### DIFF
--- a/source/deprecated/isaacsim.core.prims/python/impl/articulation.py
+++ b/source/deprecated/isaacsim.core.prims/python/impl/articulation.py
@@ -3288,8 +3288,7 @@ class Articulation(XFormPrim):
             indices: Indices to specify which prims to query. Shape (M,).
                 Where M <= size of the encapsulated prims in the view.
             joint_indices: Joint indices to specify which joints to query. Shape (K,).
-                Where K <= num of dofs for fixed-base articulations and K <= num of dofs + 6 for floating-base
-                articulations.
+                Where K <= num of dofs.
             joint_names: Joint names to specify which joints to manipulate. Cannot be specified together with
                 joint_indices. Shape (K,). Where K <= num of dofs.
             clone: True to return a clone of the internal buffer. Otherwise False.
@@ -3314,6 +3313,13 @@ class Articulation(XFormPrim):
             current_values = self._physics_view.get_gravity_compensation_forces()
             if clone:
                 current_values = self._backend_utils.clone_tensor(current_values, device=self._device)
+            if current_values.shape[-1] == self.num_dof + 6:
+                current_values = current_values[..., 6:]
+            elif current_values.shape[-1] != self.num_dof:
+                raise RuntimeError(
+                    f"Unexpected gravity compensation force shape {current_values.shape}; expected {self.num_dof} or "
+                    f"{self.num_dof + 6} values per articulation"
+                )
             result = current_values[
                 self._backend_utils.expand_dims(indices, 1) if self._backend != "warp" else indices, joint_indices
             ]

--- a/source/extensions/isaacsim.core.experimental.prims/python/impl/articulation.py
+++ b/source/extensions/isaacsim.core.experimental.prims/python/impl/articulation.py
@@ -3795,9 +3795,9 @@ class Articulation(XformPrim):
             dof_indices: Indices of DOFs to process (shape ``(D,)``). If not defined, all DOFs are processed.
 
         Returns:
-            The gravity compensation forces of the prims.
-            For fixed articulation base shape is ``(N, D)``. For non-fixed (floating) articulation base shape
-            is ``(N, D + 6)`` since the forces acting on the root are also provided.
+            The gravity compensation forces for the selected DOFs (shape ``(N, D)``).
+            For floating-base articulations, the six root-wrench values returned by the lower-level tensor API
+            are excluded.
 
         Raises:
             AssertionError: Wrapped prims are not valid.
@@ -3823,6 +3823,13 @@ class Articulation(XformPrim):
         data = (
             self._physics_articulation_view.get_gravity_compensation_forces()
         )  # shape: (N, max_dofs) or (N, max_dofs + 6)
+        if data.shape[1] == self.num_dofs + 6:
+            data = data[:, 6:]
+        elif data.shape[1] != self.num_dofs:
+            raise RuntimeError(
+                f"Unexpected gravity compensation force shape {data.shape}; expected {self.num_dofs} or "
+                f"{self.num_dofs + 6} values per articulation"
+            )
         indices = ops_utils.resolve_indices(indices, count=len(self), device=data.device)
         dof_indices = ops_utils.resolve_indices(dof_indices, count=self.num_dofs, device=data.device)
         return data[indices, dof_indices].contiguous().to(self._device)

--- a/source/extensions/isaacsim.core.experimental.prims/python/tests/test_articulation_gravity_compensation.py
+++ b/source/extensions/isaacsim.core.experimental.prims/python/tests/test_articulation_gravity_compensation.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for articulation gravity compensation DOF indexing."""
+
+import omni.kit.test
+import warp as wp
+from isaacsim.core.experimental.prims import Articulation
+
+
+class _FakePhysicsArticulationView:
+    def __init__(self, values: list[list[float]]) -> None:
+        self._values = wp.array(values, dtype=wp.float32, device="cpu")
+
+    def get_gravity_compensation_forces(self) -> wp.array:
+        return self._values
+
+
+class _FakeArticulation:
+    valid = True
+    _device = "cpu"
+
+    def __init__(self, values: list[list[float]], num_dofs: int) -> None:
+        self.num_dofs = num_dofs
+        self._physics_articulation_view = _FakePhysicsArticulationView(values)
+
+    def __len__(self) -> int:
+        return 1
+
+    def is_physics_tensor_entity_valid(self) -> bool:
+        return True
+
+
+class TestArticulationGravityCompensation(omni.kit.test.AsyncTestCase):
+    """Verify gravity compensation maps public DOF indices to joint forces."""
+
+    async def test_floating_base_root_wrench_is_excluded_before_dof_selection(self) -> None:
+        """Skip the six root-wrench entries before applying requested DOF indices."""
+        prim = _FakeArticulation(
+            [[100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 11.0, 22.0, 33.0]],
+            num_dofs=3,
+        )
+        result = Articulation.get_dof_gravity_compensation_forces(prim, dof_indices=[2, 0])
+        self.assertEqual(result.numpy().tolist(), [[33.0, 11.0]])
+
+    async def test_fixed_base_layout_is_unchanged(self) -> None:
+        """Keep direct DOF indexing when the lower-level tensor has no root prefix."""
+        prim = _FakeArticulation([[11.0, 22.0, 33.0]], num_dofs=3)
+        result = Articulation.get_dof_gravity_compensation_forces(prim, dof_indices=[1])
+        self.assertEqual(result.numpy().tolist(), [[22.0]])
+
+    async def test_unexpected_tensor_width_is_rejected(self) -> None:
+        """Fail explicitly if a backend returns an undocumented compensation layout."""
+        prim = _FakeArticulation([[1.0, 2.0, 3.0, 4.0]], num_dofs=3)
+        with self.assertRaisesRegex(RuntimeError, "Unexpected gravity compensation force shape"):
+            Articulation.get_dof_gravity_compensation_forces(prim)


### PR DESCRIPTION
## Description

Fix gravity-compensation indexing for floating-base articulations in both the current experimental API and the legacy wrapper.

The lower-level physics tensor returns `[root wrench (6) | DOF gravity forces]` for floating bases. The high-level wrappers resolved caller indices against the DOF count but applied them directly to that raw tensor, shifting every requested DOF by six and making the last six DOFs unreachable.

The fix removes the documented six-value root prefix before applying DOF selection, leaves fixed-base tensors unchanged, and rejects unexpected tensor widths.

## Validation

- regression tests cover floating-base indexing, fixed-base behaviour, and unexpected layouts
- both modified source files pass `py_compile`
- final diff contains only the two wrappers and the focused regression test

Fixes #730
