### PR TITLE
Document differential controller wheel ordering

### DIFF
--- a/source/extensions/isaacsim.robot.wheeled_robots.ui/docs/Overview.md
+++ b/source/extensions/isaacsim.robot.wheeled_robots.ui/docs/Overview.md
@@ -11,7 +11,7 @@ The `DifferentialControllerWindow` serves as the primary interface for setting u
 **Graph Generation**: The window's main functionality centers around the `make_graph()` method, which creates complete OmniGraph networks for differential drive control. The generated graphs include:
 
 - Differential controller nodes for processing drive commands
-- Articulation controller nodes for robot joint management  
+- Articulation controller nodes for robot joint management
 - Optional keyboard control nodes for manual robot operation
 - Proper node connections and parameter configurations based on user input
 
@@ -26,6 +26,10 @@ The extension integrates with Isaac Sim's menu system by adding a "Differential 
 ### Controller Configuration
 
 The extension focuses specifically on differential drive systems, which are common in wheeled mobile robots. Users can configure wheel parameters, joint mappings, and control logic through the provided interface. The resulting OmniGraph networks can then be used to control actual wheeled robots in simulation.
+
+The differential controller's velocity command uses the wheel order `[left, right]`. When selecting joints by name or index, configure the articulation controller in the same order. For example, use `["wheel_left_joint", "wheel_right_joint"]`, or the corresponding left-wheel index followed by the right-wheel index. Reversing the joint order swaps the generated wheel commands and can cause the robot to rotate when a straight-line command is expected.
+
+The Differential Controller window preserves this ordering when it constructs the joint name or joint index array: the **Left Joint** value is written first and the **Right Joint** value second.
 
 ## Integration
 


### PR DESCRIPTION
## Description

Document the wheel ordering expected by the differential controller and articulation controller joint array.

The generated velocity command is ordered `[left, right]`, so joint names or indices supplied to the articulation controller must follow the same order. Reversing them swaps the wheel commands and can make a straight command rotate the robot.

The documentation now includes:
- the `[left, right]` contract
- a `["wheel_left_joint", "wheel_right_joint"]` example
- the equivalent requirement for joint indices
- confirmation that the Differential Controller window writes Left Joint first and Right Joint second

This matches the current graph generator behavior and addresses the ambiguity reported in #647.

Addresses #647.