### PR TITLE
Preserve first prim in ROS2 entity traversal

### DIFF
--- a/source/extensions/isaacsim.ros2.sim_control/python/impl/entity_utils.py
+++ b/source/extensions/isaacsim.ros2.sim_control/python/impl/entity_utils.py
@@ -68,10 +68,9 @@ def get_filtered_entities(usdrt_stage: object, filter_pattern: str | None = None
     if not usdrt_stage:
         return [], "usdrt Stage not available for traversing"
 
-    # Get all prim paths from the usdrt stage
-
+    # Get all prim paths from the usdrt stage. Stage.Traverse() already excludes the pseudo-root.
     all_prim_paths = []
-    for prim in list(usdrt_stage.Traverse())[1:]:
+    for prim in usdrt_stage.Traverse():
         if not prim.GetPrimPath().pathString.startswith("/Render"):
             all_prim_paths.append(prim.GetPrimPath().pathString)
 

--- a/source/extensions/isaacsim.ros2.sim_control/python/tests/test_entity_utils.py
+++ b/source/extensions/isaacsim.ros2.sim_control/python/tests/test_entity_utils.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for ROS 2 simulation-control entity utilities."""
+
+import omni.kit.test
+from isaacsim.ros2.sim_control.impl.entity_utils import get_filtered_entities
+
+
+class _FakePath:
+    def __init__(self, path: str) -> None:
+        self.pathString = path
+
+
+class _FakePrim:
+    def __init__(self, path: str) -> None:
+        self._path = _FakePath(path)
+
+    def GetPrimPath(self) -> _FakePath:
+        return self._path
+
+
+class _FakeStage:
+    def __init__(self, paths: list[str]) -> None:
+        self._prims = [_FakePrim(path) for path in paths]
+
+    def Traverse(self) -> list[_FakePrim]:
+        return self._prims
+
+
+class TestEntityUtils(omni.kit.test.TestCase):
+    def test_get_filtered_entities_keeps_first_traversed_prim(self) -> None:
+        stage = _FakeStage(["/First", "/Second", "/Render/Products"])
+
+        entities, error = get_filtered_entities(stage)
+
+        self.assertEqual(error, "")
+        self.assertEqual(entities, ["/First", "/Second"])
+
+    def test_get_filtered_entities_applies_regex_to_all_prims(self) -> None:
+        stage = _FakeStage(["/RobotA", "/RobotB", "/Sensor"])
+
+        entities, error = get_filtered_entities(stage, r"Robot")
+
+        self.assertEqual(error, "")
+        self.assertEqual(entities, ["/RobotA", "/RobotB"])


### PR DESCRIPTION
## Description

Fix `get_filtered_entities()` so ROS 2 simulation-control entity queries retain the first prim returned by stage traversal.

`Stage.Traverse()` already iterates real stage prims and does not yield the pseudo-root. The existing code converted traversal to a list and sliced `[1:]`, so it silently discarded the first real prim before applying the `/Render` exclusion or optional regex filter.

The fix iterates `Traverse()` directly.

## Validation

- regression test verifies the first traversed prim is retained
- `/Render` prims remain excluded
- regex filtering still applies across all traversed prims
- final diff is one implementation file plus one focused test
