### PR TITLE
Preserve render product lists in BaseWriterNode

### DIFF
--- a/source/extensions/isaacsim.core.nodes/python/impl/base_writer_node.py
+++ b/source/extensions/isaacsim.core.nodes/python/impl/base_writer_node.py
@@ -140,7 +140,12 @@ class BaseWriterNode(BaseResetNode):
                         noop = rep.AnnotatorRegistry.get_annotator(
                             "IsaacNoop",
                         )
-                        noop.attach([request.render_product_path])
+                        render_products = (
+                            request.render_product_path
+                            if isinstance(request.render_product_path, list)
+                            else [request.render_product_path]
+                        )
+                        noop.attach(render_products)
                         carb.log_info(f"Attaching:\n{request}")
                     else:
                         request.writer.detach()

--- a/source/extensions/isaacsim.core.nodes/python/tests/test_base_writer_node.py
+++ b/source/extensions/isaacsim.core.nodes/python/tests/test_base_writer_node.py
@@ -9,13 +9,13 @@ import omni.kit.test
 from isaacsim.core.nodes import BaseWriterNode, WriterRequest
 
 
-class TestBaseWriterNode(omni.kit.test.TestCase):
+class TestBaseWriterNode(omni.kit.test.AsyncTestCase):
     """Validate writer activation requests."""
 
     @patch("isaacsim.core.nodes.impl.base_writer_node.Usd.EditContext")
     @patch("isaacsim.core.nodes.impl.base_writer_node.omni.usd.get_context")
     @patch("isaacsim.core.nodes.impl.base_writer_node.rep.AnnotatorRegistry.get_annotator")
-    def test_noop_annotator_preserves_render_product_list(
+    async def test_noop_annotator_preserves_render_product_list(
         self, mock_get_annotator: MagicMock, mock_get_context: MagicMock, mock_edit_context: MagicMock
     ) -> None:
         """A list of render products must not be wrapped in another list."""

--- a/source/extensions/isaacsim.core.nodes/python/tests/test_base_writer_node.py
+++ b/source/extensions/isaacsim.core.nodes/python/tests/test_base_writer_node.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for BaseWriterNode render-product attachment handling."""
+
+from unittest.mock import MagicMock, patch
+
+import omni.kit.test
+from isaacsim.core.nodes import BaseWriterNode, WriterRequest
+
+
+class TestBaseWriterNode(omni.kit.test.TestCase):
+    """Validate writer activation requests."""
+
+    @patch("isaacsim.core.nodes.impl.base_writer_node.Usd.EditContext")
+    @patch("isaacsim.core.nodes.impl.base_writer_node.omni.usd.get_context")
+    @patch("isaacsim.core.nodes.impl.base_writer_node.rep.AnnotatorRegistry.get_annotator")
+    def test_noop_annotator_preserves_render_product_list(
+        self, mock_get_annotator: MagicMock, mock_get_context: MagicMock, mock_edit_context: MagicMock
+    ) -> None:
+        """A list of render products must not be wrapped in another list."""
+        stage = MagicMock()
+        mock_get_context.return_value.get_stage.return_value = stage
+        mock_edit_context.return_value.__enter__.return_value = None
+        mock_edit_context.return_value.__exit__.return_value = False
+
+        writer = MagicMock()
+        writer.node_type_id = "TestWriter"
+        writer._kwargs = {}
+        writer._annotators = []
+        noop = mock_get_annotator.return_value
+
+        render_products = ["/Render/ProductA", "/Render/ProductB"]
+        node = BaseWriterNode()
+        node.post_attach = MagicMock()
+        node._requests = [WriterRequest(writer, render_products, True)]
+
+        node._process_activation_requests(MagicMock())
+
+        writer.attach.assert_called_once_with(render_products)
+        noop.attach.assert_called_once_with(render_products)


### PR DESCRIPTION
## Description

Fix multi-render-product attachment handling in `BaseWriterNode`.

`attach_writer()` and `attach_writers()` accept either a single render product path or a `list[str]`. The requested value is passed correctly to the writer, but the `IsaacNoop` annotator unconditionally wrapped it in another list:

`noop.attach([request.render_product_path])`

For a multi-render-product request this produces a nested list such as `[[path_a, path_b]]` instead of the expected `[path_a, path_b]`.

Normalize only scalar paths before attaching the no-op annotator, preserving an existing list unchanged.

## Validation

- focused regression test covers a two-render-product request
- verifies the writer and `IsaacNoop` annotator receive the same flat list
- single-path behavior remains unchanged
- production change is limited to `base_writer_node.py`
