### PR TITLE
Fix ROS2 RTX radar helper lifecycle guards

### DIFF
--- a/source/extensions/isaacsim.ros2.nodes/python/nodes/OgnROS2RtxRadarHelper.py
+++ b/source/extensions/isaacsim.ros2.nodes/python/nodes/OgnROS2RtxRadarHelper.py
@@ -152,7 +152,7 @@ class OgnROS2RtxRadarHelper:
 
         Args:
             node: OmniGraph node being released.
-            graph_instance_id: OmniGraph graph instance ID.
+            graph_instance_id: Graph instance identifier.
         """
         try:
             state = OgnROS2RtxRadarHelperInternalState.per_instance_internal_state(node)

--- a/source/extensions/isaacsim.ros2.nodes/python/nodes/OgnROS2RtxRadarHelper.py
+++ b/source/extensions/isaacsim.ros2.nodes/python/nodes/OgnROS2RtxRadarHelper.py
@@ -69,10 +69,12 @@ class OgnROS2RtxRadarHelper:
         """
         state = db.per_instance_state
 
-        if state.initialized:
+        if not db.inputs.enabled:
+            if state.initialized:
+                state.custom_reset()
             return True
 
-        if not db.inputs.enabled:
+        if state.initialized:
             return True
 
         stage = omni.usd.get_context().get_stage()
@@ -80,7 +82,8 @@ class OgnROS2RtxRadarHelper:
         if not render_product_path:
             carb.log_warn(f"Render product '{render_product_path}' not valid")
             return False
-        if stage.GetPrimAtPath(render_product_path) is None:
+        render_product_prim = stage.GetPrimAtPath(render_product_path)
+        if not render_product_prim or not render_product_prim.IsValid():
             carb.log_warn(f"Render product '{render_product_path}' not created yet, retrying on next call")
             return False
 
@@ -149,7 +152,7 @@ class OgnROS2RtxRadarHelper:
 
         Args:
             node: OmniGraph node being released.
-            graph_instance_id: Graph instance identifier.
+            graph_instance_id: OmniGraph graph instance ID.
         """
         try:
             state = OgnROS2RtxRadarHelperInternalState.per_instance_internal_state(node)

--- a/source/extensions/isaacsim.ros2.nodes/python/tests/test_rtx_radar_helper_validation.py
+++ b/source/extensions/isaacsim.ros2.nodes/python/tests/test_rtx_radar_helper_validation.py
@@ -3,10 +3,17 @@
 
 """Tests for ROS2 RTX radar helper lifecycle validation."""
 
+import importlib.util
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import omni.kit.test
-from isaacsim.ros2.nodes.OgnROS2RtxRadarHelper import OgnROS2RtxRadarHelper
+
+RADAR_HELPER_PATH = Path(__file__).resolve().parents[1] / "nodes" / "OgnROS2RtxRadarHelper.py"
+_spec = importlib.util.spec_from_file_location("_test_ros2_rtx_radar_helper", RADAR_HELPER_PATH)
+_radar_helper = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_radar_helper)
+OgnROS2RtxRadarHelper = _radar_helper.OgnROS2RtxRadarHelper
 
 
 class TestROS2RtxRadarHelperValidation(omni.kit.test.AsyncTestCase):
@@ -22,11 +29,7 @@ class TestROS2RtxRadarHelperValidation(omni.kit.test.AsyncTestCase):
 
         db.per_instance_state.custom_reset.assert_called_once_with()
 
-    @patch("isaacsim.ros2.nodes.OgnROS2RtxRadarHelper.ViewportManager.get_camera")
-    @patch("isaacsim.ros2.nodes.OgnROS2RtxRadarHelper.omni.usd.get_context")
-    async def test_missing_render_product_retries_before_camera_lookup(
-        self, mock_get_context: MagicMock, mock_get_camera: MagicMock
-    ) -> None:
+    async def test_missing_render_product_retries_before_camera_lookup(self) -> None:
         """An invalid USD prim should be rejected before resolving the radar camera."""
         db = MagicMock()
         db.inputs.enabled = True
@@ -35,8 +38,12 @@ class TestROS2RtxRadarHelperValidation(omni.kit.test.AsyncTestCase):
 
         invalid_prim = MagicMock()
         invalid_prim.IsValid.return_value = False
-        mock_get_context.return_value.get_stage.return_value.GetPrimAtPath.return_value = invalid_prim
 
-        self.assertFalse(OgnROS2RtxRadarHelper.compute(db))
+        with patch.object(_radar_helper.omni.usd, "get_context") as mock_get_context, patch.object(
+            _radar_helper.ViewportManager, "get_camera"
+        ) as mock_get_camera:
+            mock_get_context.return_value.get_stage.return_value.GetPrimAtPath.return_value = invalid_prim
 
-        mock_get_camera.assert_not_called()
+            self.assertFalse(OgnROS2RtxRadarHelper.compute(db))
+
+            mock_get_camera.assert_not_called()

--- a/source/extensions/isaacsim.ros2.nodes/python/tests/test_rtx_radar_helper_validation.py
+++ b/source/extensions/isaacsim.ros2.nodes/python/tests/test_rtx_radar_helper_validation.py
@@ -9,10 +9,10 @@ import omni.kit.test
 from isaacsim.ros2.nodes.OgnROS2RtxRadarHelper import OgnROS2RtxRadarHelper
 
 
-class TestROS2RtxRadarHelperValidation(omni.kit.test.TestCase):
+class TestROS2RtxRadarHelperValidation(omni.kit.test.AsyncTestCase):
     """Validate early lifecycle and render-product guards."""
 
-    def test_disabling_initialized_helper_resets_state(self) -> None:
+    async def test_disabling_initialized_helper_resets_state(self) -> None:
         """Disabling an active helper must detach/reset its writer state."""
         db = MagicMock()
         db.inputs.enabled = False
@@ -24,7 +24,7 @@ class TestROS2RtxRadarHelperValidation(omni.kit.test.TestCase):
 
     @patch("isaacsim.ros2.nodes.OgnROS2RtxRadarHelper.ViewportManager.get_camera")
     @patch("isaacsim.ros2.nodes.OgnROS2RtxRadarHelper.omni.usd.get_context")
-    def test_missing_render_product_retries_before_camera_lookup(
+    async def test_missing_render_product_retries_before_camera_lookup(
         self, mock_get_context: MagicMock, mock_get_camera: MagicMock
     ) -> None:
         """An invalid USD prim should be rejected before resolving the radar camera."""

--- a/source/extensions/isaacsim.ros2.nodes/python/tests/test_rtx_radar_helper_validation.py
+++ b/source/extensions/isaacsim.ros2.nodes/python/tests/test_rtx_radar_helper_validation.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ROS2 RTX radar helper lifecycle validation."""
+
+from unittest.mock import MagicMock, patch
+
+import omni.kit.test
+from isaacsim.ros2.nodes.OgnROS2RtxRadarHelper import OgnROS2RtxRadarHelper
+
+
+class TestROS2RtxRadarHelperValidation(omni.kit.test.TestCase):
+    """Validate early lifecycle and render-product guards."""
+
+    def test_disabling_initialized_helper_resets_state(self) -> None:
+        """Disabling an active helper must detach/reset its writer state."""
+        db = MagicMock()
+        db.inputs.enabled = False
+        db.per_instance_state.initialized = True
+
+        self.assertTrue(OgnROS2RtxRadarHelper.compute(db))
+
+        db.per_instance_state.custom_reset.assert_called_once_with()
+
+    @patch("isaacsim.ros2.nodes.OgnROS2RtxRadarHelper.ViewportManager.get_camera")
+    @patch("isaacsim.ros2.nodes.OgnROS2RtxRadarHelper.omni.usd.get_context")
+    def test_missing_render_product_retries_before_camera_lookup(
+        self, mock_get_context: MagicMock, mock_get_camera: MagicMock
+    ) -> None:
+        """An invalid USD prim should be rejected before resolving the radar camera."""
+        db = MagicMock()
+        db.inputs.enabled = True
+        db.inputs.renderProductPath = "/Render/MissingProduct"
+        db.per_instance_state.initialized = False
+
+        invalid_prim = MagicMock()
+        invalid_prim.IsValid.return_value = False
+        mock_get_context.return_value.get_stage.return_value.GetPrimAtPath.return_value = invalid_prim
+
+        self.assertFalse(OgnROS2RtxRadarHelper.compute(db))
+
+        mock_get_camera.assert_not_called()


### PR DESCRIPTION
## Description

Fix two early lifecycle guards in `OgnROS2RtxRadarHelper`.

First, the helper checked `state.initialized` before `inputs:enabled`. Once initialized, disabling the node therefore returned immediately without calling `custom_reset()`, leaving its writer state active.

Second, the helper tested `stage.GetPrimAtPath(render_product_path) is None`. USD returns an invalid `Usd.Prim` for a missing path rather than `None`, so the intended retry guard did not catch a render product that had not been created yet.

The helper now:
- handles `enabled=false` first and resets initialized state
- validates the render product prim with `IsValid()` before camera lookup

## Validation

- regression test verifies disabling an initialized helper calls `custom_reset()`
- regression test verifies a missing render product returns before `ViewportManager.get_camera()`
- normal initialized and valid-render-product paths are unchanged
