### PR TITLE
Fix physics sensor create return type annotation

### DIFF
--- a/source/extensions/isaacsim.sensors.experimental.physics/python/impl/_sensor_base.py
+++ b/source/extensions/isaacsim.sensors.experimental.physics/python/impl/_sensor_base.py
@@ -25,7 +25,7 @@ Mirrors the pattern in ``isaacsim.sensors.experimental.rtx``:
   ``_SensorStepManager`` registration, timeline-stop reset). Concrete sensors
   override ``_acquire_interface`` and ``_get_invalid_reading``.
 - :class:`_PhysicsSensorRuntime` extends :class:`_PhysicsSensorRuntimeBase` for
-  sensors that pair with an authoring class. Concrete sensors (e.g.
+  sensors that pair with an authoring class. Concrete classes (e.g.
   :class:`IMUSensor`) define ``_AUTHORING_CLASS`` and ``_AUTHORING_ATTR``.
   Sensors with no authoring class (e.g. :class:`EffortSensor`) inherit
   :class:`_PhysicsSensorRuntimeBase` directly.

--- a/source/extensions/isaacsim.sensors.experimental.physics/python/impl/_sensor_base.py
+++ b/source/extensions/isaacsim.sensors.experimental.physics/python/impl/_sensor_base.py
@@ -25,7 +25,7 @@ Mirrors the pattern in ``isaacsim.sensors.experimental.rtx``:
   ``_SensorStepManager`` registration, timeline-stop reset). Concrete sensors
   override ``_acquire_interface`` and ``_get_invalid_reading``.
 - :class:`_PhysicsSensorRuntime` extends :class:`_PhysicsSensorRuntimeBase` for
-  sensors that pair with an authoring class. Concrete classes (e.g.
+  sensors that pair with an authoring class. Concrete sensors (e.g.
   :class:`IMUSensor`) define ``_AUTHORING_CLASS`` and ``_AUTHORING_ATTR``.
   Sensors with no authoring class (e.g. :class:`EffortSensor`) inherit
   :class:`_PhysicsSensorRuntimeBase` directly.
@@ -33,7 +33,7 @@ Mirrors the pattern in ``isaacsim.sensors.experimental.rtx``:
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Self
 
 import carb
 import numpy as np
@@ -172,7 +172,7 @@ class _PhysicsSensorAuthoring(XformPrim):
         """
 
     @classmethod
-    def create(cls, path: str, **kwargs: Any) -> "_PhysicsSensorAuthoring":
+    def create(cls, path: str, **kwargs: Any) -> Self:
         """Create a new sensor at the specified path.
 
         Always creates a fresh prim, auto-numbering the path if it already

--- a/source/extensions/isaacsim.sensors.experimental.physics/python/impl/imu.py
+++ b/source/extensions/isaacsim.sensors.experimental.physics/python/impl/imu.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Self
 
 import numpy as np
 import omni.isaac.IsaacSensorSchema as IsaacSensorSchema
@@ -64,6 +64,11 @@ class IMU(_PhysicsSensorAuthoring):
 
     _PRIM_TYPE = "IsaacImuSensor"
     _SCHEMA_CLASS = IsaacSensorSchema.IsaacImuSensor
+
+    @classmethod
+    def create(cls, path: str, **kwargs: Any) -> Self:
+        """Create a new IMU authoring instance with a precise subclass return type."""
+        return super().create(path, **kwargs)
 
     def __init__(
         self,

--- a/source/extensions/isaacsim.sensors.experimental.physics/python/impl/imu.py
+++ b/source/extensions/isaacsim.sensors.experimental.physics/python/impl/imu.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Self
+from typing import Any
 
 import numpy as np
 import omni.isaac.IsaacSensorSchema as IsaacSensorSchema
@@ -64,11 +64,6 @@ class IMU(_PhysicsSensorAuthoring):
 
     _PRIM_TYPE = "IsaacImuSensor"
     _SCHEMA_CLASS = IsaacSensorSchema.IsaacImuSensor
-
-    @classmethod
-    def create(cls, path: str, **kwargs: Any) -> Self:
-        """Create a new IMU authoring instance with a precise subclass return type."""
-        return super().create(path, **kwargs)
 
     def __init__(
         self,


### PR DESCRIPTION
## Description

Fix the static return type of physics sensor authoring factories, including `IMU.create()`.

`_PhysicsSensorAuthoring.create()` constructs `cls(...)`, but its return annotation names the private `_PhysicsSensorAuthoring` base class. Static type checkers therefore infer calls such as `IMU.create(...)` as the base type even though the runtime object is an `IMU`.

Use `typing.Self` for the shared classmethod return type. This preserves the existing implementation and runtime behavior while allowing type checkers to infer the concrete subclass correctly for IMU and the other physics sensor authoring classes.

## Validation

- final production diff is two annotation/import lines in the shared sensor base
- no runtime creation logic or public API behavior changes
- the annotation now matches the existing `return cls(...)` implementation

Fixes #771.