### PR TITLE
Return success from IsaacReadFilePath after a valid read

### DIFF
--- a/source/extensions/isaacsim.core.nodes/python/nodes/OgnIsaacReadFilePath.py
+++ b/source/extensions/isaacsim.core.nodes/python/nodes/OgnIsaacReadFilePath.py
@@ -30,7 +30,7 @@ class OgnIsaacReadFilePath:
             db: OmniGraph database for this node.
 
         Returns:
-            False when the input path is empty or missing.
+            False when the input path is empty or missing, True after a successful read.
         """
         # Empty input:
         db.outputs.fileContents = ""
@@ -43,3 +43,4 @@ class OgnIsaacReadFilePath:
         else:
             with open(db.inputs.path) as f:
                 db.outputs.fileContents = f.read()
+        return True

--- a/source/extensions/isaacsim.core.nodes/python/tests/test_read_file_path_success.py
+++ b/source/extensions/isaacsim.core.nodes/python/tests/test_read_file_path_success.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for the IsaacReadFilePath compute return value."""
+
+import tempfile
+from types import SimpleNamespace
+
+import omni.kit.test
+from isaacsim.core.nodes.ogn.python.nodes.OgnIsaacReadFilePath import OgnIsaacReadFilePath
+
+
+class TestReadFilePathSuccess(omni.kit.test.AsyncTestCase):
+    """Verify successful file reads report successful OmniGraph computation."""
+
+    async def test_successful_read_returns_true(self) -> None:
+        """A valid file should populate the output and return True."""
+        with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8") as file:
+            file.write("hello Isaac Sim")
+            file.flush()
+
+            db = SimpleNamespace(
+                inputs=SimpleNamespace(path=file.name),
+                outputs=SimpleNamespace(fileContents=""),
+                log_warn=lambda _message: None,
+            )
+
+            self.assertTrue(OgnIsaacReadFilePath.compute(db))
+            self.assertEqual(db.outputs.fileContents, "hello Isaac Sim")


### PR DESCRIPTION
## Description

Make `IsaacReadFilePath.compute()` return `True` after successfully reading a file.

The node explicitly returns `False` for an empty or missing path, but the successful branch currently populates `outputs:fileContents` and then falls off the end of the function, implicitly returning `None`.

Python OmniGraph compute implementations in this extension use a boolean result to report compute success. Returning `None` on the only successful path makes the node's status inconsistent with both its error paths and neighbouring nodes.

Add the missing `return True` after a successful read and clarify the return-value docstring.

## Validation

- regression test reads a temporary UTF-8 file through the node implementation
- verifies the file contents are populated
- verifies the compute result is `True`
- missing/empty-path behavior remains unchanged
