### PR TITLE
Refresh HolonomicController when wheel geometry changes

### DIFF
--- a/source/extensions/isaacsim.robot.wheeled_robots.nodes/python/nodes/OgnHolonomicController.py
+++ b/source/extensions/isaacsim.robot.wheeled_robots.nodes/python/nodes/OgnHolonomicController.py
@@ -132,58 +132,48 @@ class OgnHolonomicController:
         state = db.per_instance_state
 
         try:
-            stop = False
-            error_log = ""
-            if len(db.inputs.wheelRadius) == 0:
-                error_log += "Wheel radius list is empty\n"
-                stop = True
-            if len(db.inputs.wheelPositions) == 0:
-                error_log += "Wheel positions list is empty\n"
-                stop = True
-            if len(db.inputs.wheelOrientations) == 0:
-                error_log += "Wheel orientations list is empty\n"
-                stop = True
-            if len(db.inputs.mecanumAngles) == 0:
-                error_log += "Mecanum angles list is empty\n"
-                stop = True
-            if stop:
-                db.log_warning(error_log)
-                return False
+            if state.initialized and (
+                not np.array_equal(db.inputs.wheelRadius, state.wheel_radius)
+                or not np.array_equal(db.inputs.wheelPositions, state.wheel_positions)
+                or not np.array_equal(db.inputs.wheelOrientations, state.wheel_orientations)
+                or not np.array_equal(db.inputs.mecanumAngles, state.mecanum_angles)
+                or not np.array_equal(db.inputs.wheelAxis, state.wheel_axis)
+                or not np.array_equal(db.inputs.upAxis, state.up_axis)
+            ):
+                state.initialized = False
 
-            wheel_radius = np.asarray(db.inputs.wheelRadius)
-            wheel_positions = np.asarray(db.inputs.wheelPositions)
-            wheel_orientations = np.asarray(db.inputs.wheelOrientations)
-            mecanum_angles = np.asarray(db.inputs.mecanumAngles)
-            wheel_axis = np.asarray(db.inputs.wheelAxis)
-            up_axis = np.asarray(db.inputs.upAxis)
+            if not state.initialized:
+                stop = False
+                error_log = ""
+                # TODO: Add a check to see if the wheel radius is valid
+                if len(db.inputs.wheelRadius) == 0:
+                    error_log += "Wheel radius list is empty\n"
+                    stop = True
+                if len(db.inputs.wheelPositions) == 0:
+                    error_log += "Wheel positions list is empty\n"
+                    stop = True
+                if len(db.inputs.wheelOrientations) == 0:
+                    error_log += "Wheel orientations list is empty\n"
+                    stop = True
+                if len(db.inputs.mecanumAngles) == 0:
+                    error_log += "Mecanum angles list is empty\n"
+                    stop = True
+                if stop:
+                    db.log_warning(error_log)
+                    return False
 
-            configuration_changed = (
-                not state.initialized
-                or not np.array_equal(wheel_radius, np.asarray(state.wheel_radius))
-                or not np.array_equal(wheel_positions, np.asarray(state.wheel_positions))
-                or not np.array_equal(wheel_orientations, np.asarray(state.wheel_orientations))
-                or not np.array_equal(mecanum_angles, np.asarray(state.mecanum_angles))
-                or not np.array_equal(wheel_axis, np.asarray(state.wheel_axis))
-                or not np.array_equal(up_axis, np.asarray(state.up_axis))
-                or state.max_linear_speed != db.inputs.maxLinearSpeed
-                or state.max_angular_speed != db.inputs.maxAngularSpeed
-                or state.max_wheel_speed != db.inputs.maxWheelSpeed
-                or state.linear_gain != db.inputs.linearGain
-                or state.angular_gain != db.inputs.angularGain
-            )
-
-            if configuration_changed:
-                state.wheel_radius = wheel_radius.copy()
-                state.wheel_positions = wheel_positions.copy()
-                state.wheel_orientations = wheel_orientations.copy()
-                state.mecanum_angles = mecanum_angles.copy()
-                state.wheel_axis = wheel_axis.copy()
-                state.up_axis = up_axis.copy()
+                state.wheel_radius = db.inputs.wheelRadius
+                state.wheel_positions = db.inputs.wheelPositions
+                state.wheel_orientations = db.inputs.wheelOrientations
+                state.mecanum_angles = db.inputs.mecanumAngles
+                state.wheel_axis = db.inputs.wheelAxis
+                state.up_axis = db.inputs.upAxis
                 state.max_linear_speed = db.inputs.maxLinearSpeed
                 state.max_angular_speed = db.inputs.maxAngularSpeed
                 state.max_wheel_speed = db.inputs.maxWheelSpeed
                 state.linear_gain = db.inputs.linearGain
                 state.angular_gain = db.inputs.angularGain
+
                 state.initialize_controller()
 
             wheel_velocities = state.forward(np.array(db.inputs.inputVelocity))

--- a/source/extensions/isaacsim.robot.wheeled_robots.nodes/python/nodes/OgnHolonomicController.py
+++ b/source/extensions/isaacsim.robot.wheeled_robots.nodes/python/nodes/OgnHolonomicController.py
@@ -132,38 +132,58 @@ class OgnHolonomicController:
         state = db.per_instance_state
 
         try:
-            if not state.initialized:
-                stop = False
-                error_log = ""
-                # TODO: Add a check to see if the wheel radius is valid
-                if len(db.inputs.wheelRadius) == 0:
-                    error_log += "Wheel radius list is empty\n"
-                    stop = True
-                if len(db.inputs.wheelPositions) == 0:
-                    error_log += "Wheel positions list is empty\n"
-                    stop = True
-                if len(db.inputs.wheelOrientations) == 0:
-                    error_log += "Wheel orientations list is empty\n"
-                    stop = True
-                if len(db.inputs.mecanumAngles) == 0:
-                    error_log += "Mecanum angles list is empty\n"
-                    stop = True
-                if stop:
-                    db.log_warning(error_log)
-                    return False
+            stop = False
+            error_log = ""
+            if len(db.inputs.wheelRadius) == 0:
+                error_log += "Wheel radius list is empty\n"
+                stop = True
+            if len(db.inputs.wheelPositions) == 0:
+                error_log += "Wheel positions list is empty\n"
+                stop = True
+            if len(db.inputs.wheelOrientations) == 0:
+                error_log += "Wheel orientations list is empty\n"
+                stop = True
+            if len(db.inputs.mecanumAngles) == 0:
+                error_log += "Mecanum angles list is empty\n"
+                stop = True
+            if stop:
+                db.log_warning(error_log)
+                return False
 
-                state.wheel_radius = db.inputs.wheelRadius
-                state.wheel_positions = db.inputs.wheelPositions
-                state.wheel_orientations = db.inputs.wheelOrientations
-                state.mecanum_angles = db.inputs.mecanumAngles
-                state.wheel_axis = db.inputs.wheelAxis
-                state.up_axis = db.inputs.upAxis
+            wheel_radius = np.asarray(db.inputs.wheelRadius)
+            wheel_positions = np.asarray(db.inputs.wheelPositions)
+            wheel_orientations = np.asarray(db.inputs.wheelOrientations)
+            mecanum_angles = np.asarray(db.inputs.mecanumAngles)
+            wheel_axis = np.asarray(db.inputs.wheelAxis)
+            up_axis = np.asarray(db.inputs.upAxis)
+
+            configuration_changed = (
+                not state.initialized
+                or not np.array_equal(wheel_radius, np.asarray(state.wheel_radius))
+                or not np.array_equal(wheel_positions, np.asarray(state.wheel_positions))
+                or not np.array_equal(wheel_orientations, np.asarray(state.wheel_orientations))
+                or not np.array_equal(mecanum_angles, np.asarray(state.mecanum_angles))
+                or not np.array_equal(wheel_axis, np.asarray(state.wheel_axis))
+                or not np.array_equal(up_axis, np.asarray(state.up_axis))
+                or state.max_linear_speed != db.inputs.maxLinearSpeed
+                or state.max_angular_speed != db.inputs.maxAngularSpeed
+                or state.max_wheel_speed != db.inputs.maxWheelSpeed
+                or state.linear_gain != db.inputs.linearGain
+                or state.angular_gain != db.inputs.angularGain
+            )
+
+            if configuration_changed:
+                state.wheel_radius = wheel_radius.copy()
+                state.wheel_positions = wheel_positions.copy()
+                state.wheel_orientations = wheel_orientations.copy()
+                state.mecanum_angles = mecanum_angles.copy()
+                state.wheel_axis = wheel_axis.copy()
+                state.up_axis = up_axis.copy()
                 state.max_linear_speed = db.inputs.maxLinearSpeed
                 state.max_angular_speed = db.inputs.maxAngularSpeed
                 state.max_wheel_speed = db.inputs.maxWheelSpeed
                 state.linear_gain = db.inputs.linearGain
                 state.angular_gain = db.inputs.angularGain
-
                 state.initialize_controller()
 
             wheel_velocities = state.forward(np.array(db.inputs.inputVelocity))

--- a/source/extensions/isaacsim.robot.wheeled_robots.nodes/python/tests/test_holonomic_controller_input_refresh.py
+++ b/source/extensions/isaacsim.robot.wheeled_robots.nodes/python/tests/test_holonomic_controller_input_refresh.py
@@ -3,13 +3,27 @@
 
 """Regression coverage for HolonomicController runtime configuration refresh."""
 
+import isaacsim.core.experimental.utils.app as app_utils
+import isaacsim.core.experimental.utils.stage as stage_utils
 import numpy as np
 import omni.graph.core as og
 import omni.graph.core.tests as ogts
+import omni.kit.stage_templates
 
 
 class TestHolonomicControllerInputRefresh(ogts.OmniGraphTestCase):
     """Verify changed wheel geometry is applied without resetting the graph."""
+
+    async def setUp(self) -> None:
+        await stage_utils.create_new_stage_async()
+        stage_utils.set_stage_up_axis("Z")
+        stage_utils.set_stage_units(meters_per_unit=1.0)
+        await app_utils.update_app_async()
+
+    async def tearDown(self) -> None:
+        app_utils.stop()
+        await app_utils.update_app_async()
+        await omni.kit.stage_templates.new_stage_async()
 
     async def test_wheel_radius_change_rebuilds_controller(self) -> None:
         graph, [controller], _, _ = og.Controller.edit(
@@ -41,7 +55,7 @@ class TestHolonomicControllerInputRefresh(ogts.OmniGraphTestCase):
         await og.Controller.evaluate(graph)
         first = np.asarray(og.Controller(og.Controller.attribute("outputs:jointVelocityCommand", controller)).get())
 
-        og.Controller(og.Controller.attribute("inputs:wheelRadius", controller)).set([0.08, 0.08, 0.08])
+        og.Controller.attribute("inputs:wheelRadius", controller).set([0.08, 0.08, 0.08])
         await og.Controller.evaluate(graph)
         second = np.asarray(og.Controller(og.Controller.attribute("outputs:jointVelocityCommand", controller)).get())
 

--- a/source/extensions/isaacsim.robot.wheeled_robots.nodes/python/tests/test_holonomic_controller_input_refresh.py
+++ b/source/extensions/isaacsim.robot.wheeled_robots.nodes/python/tests/test_holonomic_controller_input_refresh.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for HolonomicController runtime configuration refresh."""
+
+import numpy as np
+import omni.graph.core as og
+import omni.graph.core.tests as ogts
+
+
+class TestHolonomicControllerInputRefresh(ogts.OmniGraphTestCase):
+    """Verify changed wheel geometry is applied without resetting the graph."""
+
+    async def test_wheel_radius_change_rebuilds_controller(self) -> None:
+        graph, [controller], _, _ = og.Controller.edit(
+            {"graph_path": "/ActionGraph"},
+            {
+                og.Controller.Keys.CREATE_NODES: [
+                    ("HolonomicController", "isaacsim.robot.wheeled_robots.HolonomicController"),
+                ],
+                og.Controller.Keys.SET_VALUES: [
+                    ("HolonomicController.inputs:wheelRadius", [0.04, 0.04, 0.04]),
+                    (
+                        "HolonomicController.inputs:wheelPositions",
+                        [
+                            [-0.0980432, 0.000636773, -0.050501],
+                            [0.0493475, -0.084525, -0.050501],
+                            [0.0495291, 0.0856937, -0.050501],
+                        ],
+                    ),
+                    (
+                        "HolonomicController.inputs:wheelOrientations",
+                        [[0, 0, 0, 1], [0.866, 0, 0, -0.5], [0.866, 0, 0, 0.5]],
+                    ),
+                    ("HolonomicController.inputs:mecanumAngles", [90, 90, 90]),
+                    ("HolonomicController.inputs:inputVelocity", [1.0, 1.0, 0.1]),
+                ],
+            },
+        )
+
+        await og.Controller.evaluate(graph)
+        first = np.asarray(og.Controller(og.Controller.attribute("outputs:jointVelocityCommand", controller)).get())
+
+        og.Controller(og.Controller.attribute("inputs:wheelRadius", controller)).set([0.08, 0.08, 0.08])
+        await og.Controller.evaluate(graph)
+        second = np.asarray(og.Controller(og.Controller.attribute("outputs:jointVelocityCommand", controller)).get())
+
+        self.assertTrue(np.all(np.isfinite(first)))
+        self.assertTrue(np.all(np.isfinite(second)))
+        self.assertTrue(np.allclose(second, first / 2.0, rtol=1e-4, atol=1e-4))


### PR DESCRIPTION
## Description

Make `HolonomicController` refresh its cached controller when wheel geometry inputs change at runtime.

The node currently copies `wheelRadius`, `wheelPositions`, `wheelOrientations`, `mecanumAngles`, `wheelAxis`, and `upAxis` only during its first initialization. This means a graph that retargets `HolonomicRobotUsdSetup` to another robot can supply new wheel geometry while `HolonomicController` continues computing commands with the previous robot's geometry.

When an initialized node detects a change in any wheel-geometry input, mark the cached controller uninitialized and reuse the existing validation/initialization path to rebuild it. Steady-state behavior is unchanged when geometry inputs are stable.

## Validation

- regression test evaluates the controller with 0.04 m wheel radii
- doubles all wheel radii to 0.08 m without resetting the graph
- verifies the next evaluation immediately uses the new geometry and halves the required wheel angular velocities
- existing initialization and validation path is reused unchanged
- production diff is ten lines
