### PR TITLE
Initialize viewport state before missing lookup handling

### DIFF
--- a/source/extensions/isaacsim.core.nodes/python/nodes/OgnIsaacGetViewportRenderProduct.py
+++ b/source/extensions/isaacsim.core.nodes/python/nodes/OgnIsaacGetViewportRenderProduct.py
@@ -27,7 +27,7 @@ class OgnIsaacGetViewportRenderProductInternalState:
     """Per-instance cache for the viewport API resolved from the input window name."""
 
     def __init__(self) -> None:
-        viewport = None
+        self.viewport = None
 
 
 class OgnIsaacGetViewportRenderProduct:
@@ -60,7 +60,7 @@ class OgnIsaacGetViewportRenderProduct:
         if viewport_api:
             db.per_instance_state.viewport = viewport_api
         if db.per_instance_state.viewport is None:
-            carb.log_warn("viewport name {db.inputs.viewport} not found")
+            carb.log_warn(f"viewport name {db.inputs.viewport} not found")
             db.per_instance_state.initialized = False
             return False
 

--- a/source/extensions/isaacsim.core.nodes/python/tests/test_get_viewport_render_product_missing.py
+++ b/source/extensions/isaacsim.core.nodes/python/tests/test_get_viewport_render_product_missing.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for missing viewport lookup state."""
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import omni.kit.test
+
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "nodes" / "OgnIsaacGetViewportRenderProduct.py"
+_SPEC = importlib.util.spec_from_file_location("_ogn_get_viewport_render_product_test", _MODULE_PATH)
+_MODULE = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_MODULE)
+
+
+class TestGetViewportRenderProductMissing(omni.kit.test.AsyncTestCase):
+    """Verify a missing viewport follows the documented False-return path."""
+
+    async def test_missing_viewport_does_not_raise_for_uninitialized_cache(self) -> None:
+        state = _MODULE.OgnIsaacGetViewportRenderProductInternalState()
+        db = SimpleNamespace(
+            per_instance_state=state,
+            inputs=SimpleNamespace(viewport="MissingViewport"),
+            outputs=SimpleNamespace(),
+        )
+
+        with patch.object(_MODULE, "get_viewport_from_window_name", return_value=None), patch.object(
+            _MODULE.carb, "log_warn"
+        ) as log_warn:
+            result = _MODULE.OgnIsaacGetViewportRenderProduct.compute(db)
+
+        self.assertFalse(result)
+        self.assertIsNone(state.viewport)
+        self.assertFalse(state.initialized)
+        log_warn.assert_called_once_with("viewport name MissingViewport not found")


### PR DESCRIPTION
## Description

Fix the missing-viewport path in `IsaacGetViewportRenderProduct`.

`OgnIsaacGetViewportRenderProductInternalState.__init__()` currently assigns `viewport = None` to a local variable instead of `self.viewport`. If `get_viewport_from_window_name()` cannot resolve the requested viewport on the first compute, the node then evaluates `db.per_instance_state.viewport is None` before that attribute exists and can raise `AttributeError` instead of following its documented warning/`False` path.

Initialize the instance cache correctly with `self.viewport = None`. Also make the existing warning interpolate the requested viewport name instead of logging the literal `{db.inputs.viewport}` text.

## Validation

- focused regression test forces a viewport lookup miss on a fresh internal state
- verifies `compute()` returns `False` rather than raising
- verifies the cache remains `None` and the node is marked uninitialized
- verifies the warning includes the requested viewport name
- production diff is two corrected lines
